### PR TITLE
Added better support for metadata

### DIFF
--- a/inc/extend-attachment-update.php
+++ b/inc/extend-attachment-update.php
@@ -1,0 +1,17 @@
+<?php
+
+if ( ! defined ( 'ABSPATH' ) ) {
+	die ( 'No script kiddies please!' );
+}
+
+function yoimg_generate_attachment_metadata($metadata, $id){
+	if($id){
+		$yoimg_meta_data = wp_get_attachment_metadata($id, true);
+		if( isset( $yoimg_meta_data['yoimg_attachment_metadata'] ) && ! isset( $metadata['yoimg_attachment_metadata'] ) ) {
+			$metadata['yoimg_attachment_metadata'] = $yoimg_meta_data['yoimg_attachment_metadata'];
+		}
+	}
+	return $metadata;
+}
+
+add_filter('wp_generate_attachment_metadata','yoimg_generate_attachment_metadata', 2 , 2);

--- a/inc/init.php
+++ b/inc/init.php
@@ -5,6 +5,7 @@ if (! defined ( 'ABSPATH' )) {
 
 if (is_admin ()) {
 	
+if (is_admin () || php_sapi_name() == 'cli' ) {
 	define ( 'YOIMG_CROP_PATH', dirname ( __FILE__ ) );
 	
 	define ( 'YOIMG_DEFAULT_CROP_ENABLED', TRUE );
@@ -28,6 +29,7 @@ if (is_admin ()) {
 		require_once (YOIMG_CROP_PATH . '/extend-admin-media-lightbox.php');
 		require_once (YOIMG_CROP_PATH . '/extend-admin-post.php');
 		require_once (YOIMG_CROP_PATH . '/extend-admin-options-media.php');
+		require_once (YOIMG_CROP_PATH . '/extend-attachment-update.php');
 	}
 }
 function yoimg_crop_load_styles_and_scripts($hook) {


### PR DESCRIPTION
This should implement https://github.com/sirulli/yoimages/issues/33 .
Had to add a check to make the plugin support CLI commands (http://wp-cli.org/).

This should prevent other plugins, that regenerate attachment metadata, from deleting the custom metadata created by yoimage.
