### PR TITLE
Trigger an action after the image is cropped

### DIFF
--- a/inc/image-editor.php
+++ b/inc/image-editor.php
@@ -96,6 +96,8 @@ function yoimg_crop_image() {
 					'smaller' => $is_crop_smaller )
 			);
 		}
+
+		do_action('yoimg_post_crop_image');
 	}
 	die();
 }


### PR DESCRIPTION
We're enjoying using your plugin, so thanks first of all.

What we've found is that we need to carry out an action after Yo Images carries out a crop - basically so we can flush and recreate the resized images that we've created for that particular crop.
