### PR TITLE
Make crop sizes customizable through Wordpress filters

### DIFF
--- a/inc/html/edit-image-size.php
+++ b/inc/html/edit-image-size.php
@@ -100,7 +100,7 @@ if ( $has_replacement ) {
 								$anchor_class = $is_current_size ? 'active' : '';
 								$anchor_href = yoimg_get_edit_image_url( $yoimg_image_id, $size_key ) . '&partial=1';
 								?>
-								<a href="<?php echo $anchor_href; ?>" class="media-menu-item yoimg-thickbox yoimg-thickbox-partial <?php echo $anchor_class; ?>"><?php _e(ucwords(str_replace('-', ' ', $size_key))); ?></a>
+								<a href="<?php echo $anchor_href; ?>" class="media-menu-item yoimg-thickbox yoimg-thickbox-partial <?php echo $anchor_class; ?>"><?php _e( apply_filters( 'yoimg_crop_size_label', ucwords(str_replace('-', ' ', $size_key)), $size_key)); ?></a>
 						<?php
 							}
 						}

--- a/inc/utils.php
+++ b/inc/utils.php
@@ -59,5 +59,5 @@ function yoimg_get_image_sizes( $size = '' ) {
 			return false;
 		}
 	}
-	return $sizes;
+	return apply_filters( 'yoimg_crop_sizes', $sizes );
 }


### PR DESCRIPTION
Could I please suggest something along these lines, so that theme developers are able to customise which sizes appear in the cropping interface, and how they are labelled for the user?

Currrently these don't appear to be customisable, so this small tweak would be a big help.
