### PR TITLE
Cachebusting filename option

### DIFF
--- a/inc/extend-yoimg-settings.php
+++ b/inc/extend-yoimg-settings.php
@@ -96,7 +96,7 @@ function yoimg_crop_settings_cachebust_new_crops_callback() {
     $check_value = 'checked="checked"';
   }
 
-	printf ( '<input type="checkbox" id="cachebusting_is_active-id" class="cachebusting_is_active-dep" name="yoimg_crop_settings[cachebusting_is_active]" value="TRUE" %s />
+	printf ( '<input type="checkbox" id="cachebusting_is_active" class="cropping_is_active-dep" name="yoimg_crop_settings[cachebusting_is_active]" value="TRUE" %s />
 				<p class="description">' . __ ( 'Generate a new filename after cropping images so that they are updated by external caches and CDNs.', YOIMG_DOMAIN ) . '</p>',
         $check_value );
 }

--- a/inc/extend-yoimg-settings.php
+++ b/inc/extend-yoimg-settings.php
@@ -96,7 +96,7 @@ function yoimg_crop_settings_cachebust_new_crops_callback() {
     $check_value = 'checked="checked"';
   }
 
-	printf ( '<input type="checkbox" id="cachebusting_is_active" class="cachebusting_is_active-dep" name="yoimg_crop_settings[cachebusting_is_active]" value="TRUE" %s />
+	printf ( '<input type="checkbox" id="cachebusting_is_active-id" class="cachebusting_is_active-dep" name="yoimg_crop_settings[cachebusting_is_active]" value="TRUE" %s />
 				<p class="description">' . __ ( 'Generate a new filename after cropping images so that they are updated by external caches and CDNs.', YOIMG_DOMAIN ) . '</p>',
         $check_value );
 }

--- a/inc/extend-yoimg-settings.php
+++ b/inc/extend-yoimg-settings.php
@@ -91,12 +91,10 @@ function yoimg_crop_settings_cropping_sizes_callback() {
 // Create the cachebuster setting checkbox
 function yoimg_crop_settings_cachebust_new_crops_callback() {
 	$crop_options = get_option ( 'yoimg_crop_settings' );
-  var_dump($crop_options);
   $check_value = '';
   if( $crop_options['cachebusting_is_active'] || YOIMG_DEFAULT_CACHEBUSTER_ENABLED && !isset($crop_options['cachebusting_is_active']) ) {
     $check_value = 'checked="checked"';
   }
-  var_dump($check_value);
 
 	printf ( '<input type="checkbox" id="cachebusting_is_active" class="cachebusting_is_active-dep" name="yoimg_crop_settings[cachebusting_is_active]" value="TRUE" %s />
 				<p class="description">' . __ ( 'Generate a new filename after cropping images so that they are updated by external caches and CDNs.', YOIMG_DOMAIN ) . '</p>',
@@ -148,11 +146,7 @@ function yoimg_crop_settings_sanitize($input) {
 	} else {
 		$new_input ['cachebusting_is_active'] = FALSE;
 	}
-  var_dump($input);
-  var_dump($new_input);
-  die();
 
-  // $new_input ['cachebusting_is_active'] = TRUE;
 	if (isset ( $input ['crop_sizes'] )) {
 		$there_is_one_manual_crop_active = FALSE;
 		foreach ( $input['crop_sizes'] as $crop_size_id => $crop_size_option ) {

--- a/inc/extend-yoimg-settings.php
+++ b/inc/extend-yoimg-settings.php
@@ -19,27 +19,32 @@ function yoimg_crop_extend_settings($settings) {
 											array (
 													'id' => 'cropping_is_active',
 													'title' => __ ( 'Enable', YOIMG_DOMAIN ),
-													'callback' => 'yoimg_crop_settings_cropping_is_active_callback' 
+													'callback' => 'yoimg_crop_settings_cropping_is_active_callback'
 											),
 											array (
 													'id' => 'crop_qualities',
 													'title' => __ ( 'Crop qualities', YOIMG_DOMAIN ),
-													'callback' => 'yoimg_crop_settings_crop_qualities_callback' 
+													'callback' => 'yoimg_crop_settings_crop_qualities_callback'
 											),
 											array (
 													'id' => 'retina_cropping_is_active',
 													'title' => __ ( 'Retina friendly', YOIMG_DOMAIN ),
-													'callback' => 'yoimg_crop_settings_retina_cropping_is_active_callback' 
+													'callback' => 'yoimg_crop_settings_retina_cropping_is_active_callback'
 											),
 											array (
 													'id' => 'cropping_sizes',
 													'title' => __ ( 'Cropping sizes', YOIMG_DOMAIN ),
-													'callback' => 'yoimg_crop_settings_cropping_sizes_callback' 
-											)  
-									) 
-							) 
-					) 
-			) 
+													'callback' => 'yoimg_crop_settings_cropping_sizes_callback'
+											),
+											array (
+													'id' => 'cachebusting_is_active',
+													'title' => __ ( 'Cachebust new crops', YOIMG_DOMAIN ),
+													'callback' => 'yoimg_crop_settings_cachebust_new_crops_callback'
+											)
+									)
+							)
+					)
+			)
 	);
 	array_push ( $settings, $crop_settings );
 	return $settings;
@@ -83,6 +88,20 @@ function yoimg_crop_settings_cropping_sizes_callback() {
 	}
 	print ( '</table>' );
 }
+// Create the cachebuster setting checkbox
+function yoimg_crop_settings_cachebust_new_crops_callback() {
+	$crop_options = get_option ( 'yoimg_crop_settings' );
+  var_dump($crop_options);
+  $check_value = '';
+  if( $crop_options['cachebusting_is_active'] || YOIMG_DEFAULT_CACHEBUSTER_ENABLED && !isset($crop_options['cachebusting_is_active']) ) {
+    $check_value = 'checked="checked"';
+  }
+  var_dump($check_value);
+
+	printf ( '<input type="checkbox" id="cachebusting_is_active" class="cachebusting_is_active-dep" name="yoimg_crop_settings[cachebusting_is_active]" value="TRUE" %s />
+				<p class="description">' . __ ( 'Generate a new filename after cropping images so that they are updated by external caches and CDNs.', YOIMG_DOMAIN ) . '</p>',
+        $check_value );
+}
 function yoimg_crop_settings_section_info() {
 	print __ ( 'Enter your cropping settings here below', YOIMG_DOMAIN );
 }
@@ -124,6 +143,16 @@ function yoimg_crop_settings_sanitize($input) {
 	} else {
 		$new_input ['retina_cropping_is_active'] = FALSE;
 	}
+  if (isset ( $input ['cachebusting_is_active'] ) && ($input ['cachebusting_is_active'] === 'TRUE' || $input ['cachebusting_is_active'] === TRUE)) {
+		$new_input ['cachebusting_is_active'] = TRUE;
+	} else {
+		$new_input ['cachebusting_is_active'] = FALSE;
+	}
+  var_dump($input);
+  var_dump($new_input);
+  die();
+
+  // $new_input ['cachebusting_is_active'] = TRUE;
 	if (isset ( $input ['crop_sizes'] )) {
 		$there_is_one_manual_crop_active = FALSE;
 		foreach ( $input['crop_sizes'] as $crop_size_id => $crop_size_option ) {

--- a/inc/init.php
+++ b/inc/init.php
@@ -23,7 +23,7 @@ if (is_admin () || php_sapi_name () == 'cli') {
   define ( 'YOIMG_CROP_RETINA_ENABLED', $yoimg_crop_settings && isset ( $yoimg_crop_settings ['retina_cropping_is_active'] ) ? $yoimg_crop_settings ['retina_cropping_is_active'] : YOIMG_DEFAULT_CROP_RETINA_ENABLED );
 	define ( 'YOIMG_CACHEBUSTER_ENABLED', $yoimg_crop_settings && isset ( $yoimg_crop_settings ['cachebuster_is_active'] ) ? $yoimg_crop_settings ['cachebuster_is_active'] : YOIMG_DEFAULT_CACHEBUSTER_ENABLED );
   // define ( 'YOIMG_CROP_URL', plugins_url ( plugin_basename ( YOIMG_CROP_PATH ) ) );
-	define ( 'YOIMG_CROP_URL', '/../app/plugins/yoimages/vendor/sirulli/yoimages-crop/inc' ); // TODO: work out why this is wrong
+	define ( 'YOIMG_CROP_URL', '/../app/plugins/yoimages/vendor/sirulli/yoimages-crop/inc' ); // TODO: work out why the base url is sometimes wrong...
 	require_once (YOIMG_CROP_PATH . '/utils.php');
 	if (YOIMG_CROP_ENABLED) {
 		require_once (YOIMG_CROP_PATH . '/image-editor.php');

--- a/inc/init.php
+++ b/inc/init.php
@@ -6,19 +6,24 @@ if (! defined ( 'ABSPATH' )) {
 if (is_admin () || php_sapi_name () == 'cli') {
 
 	define ( 'YOIMG_CROP_PATH', dirname ( __FILE__ ) );
-	
+
 	define ( 'YOIMG_DEFAULT_CROP_ENABLED', TRUE );
 	define ( 'YOIMG_DEFAULT_CROP_QUALITIES', serialize ( array (
 			100,
 			80,
-			60 
+			60
 	) ) );
 	$yoimg_crop_settings = get_option ( 'yoimg_crop_settings' );
+  // var_dump($yoimg_crop_settings);
+  // die();
 	define ( 'YOIMG_CROP_ENABLED', $yoimg_crop_settings && isset ( $yoimg_crop_settings ['cropping_is_active'] ) ? $yoimg_crop_settings ['cropping_is_active'] : YOIMG_DEFAULT_CROP_ENABLED );
 	define ( 'YOIMG_EDIT_IMAGE_ACTION', 'yoimg-edit-thumbnails' );
-	define ( 'YOIMG_DEFAULT_CROP_RETINA_ENABLED', FALSE );
-	define ( 'YOIMG_CROP_RETINA_ENABLED', $yoimg_crop_settings && isset ( $yoimg_crop_settings ['retina_cropping_is_active'] ) ? $yoimg_crop_settings ['retina_cropping_is_active'] : YOIMG_DEFAULT_CROP_RETINA_ENABLED );
-	define ( 'YOIMG_CROP_URL', plugins_url ( plugin_basename ( YOIMG_CROP_PATH ) ) );
+  define ( 'YOIMG_DEFAULT_CROP_RETINA_ENABLED', FALSE );
+	define ( 'YOIMG_DEFAULT_CACHEBUSTER_ENABLED', FALSE );
+  define ( 'YOIMG_CROP_RETINA_ENABLED', $yoimg_crop_settings && isset ( $yoimg_crop_settings ['retina_cropping_is_active'] ) ? $yoimg_crop_settings ['retina_cropping_is_active'] : YOIMG_DEFAULT_CROP_RETINA_ENABLED );
+	define ( 'YOIMG_CACHEBUSTER_ENABLED', $yoimg_crop_settings && isset ( $yoimg_crop_settings ['cachebuster_is_active'] ) ? $yoimg_crop_settings ['cachebuster_is_active'] : YOIMG_DEFAULT_CACHEBUSTER_ENABLED );
+  // define ( 'YOIMG_CROP_URL', plugins_url ( plugin_basename ( YOIMG_CROP_PATH ) ) );
+	define ( 'YOIMG_CROP_URL', '/../app/plugins/yoimages/vendor/sirulli/yoimages-crop/inc' ); // TODO: work out why this is wrong
 	require_once (YOIMG_CROP_PATH . '/utils.php');
 	if (YOIMG_CROP_ENABLED) {
 		require_once (YOIMG_CROP_PATH . '/image-editor.php');
@@ -39,7 +44,7 @@ function yoimg_crop_load_styles_and_scripts($hook) {
 			$mode = get_user_option ( 'media_library_mode', get_current_user_id () ) ? get_user_option ( 'media_library_mode', get_current_user_id () ) : 'grid';
 			$modes = array (
 					'grid',
-					'list' 
+					'list'
 			);
 			if (isset ( $_GET ['mode'] ) && in_array ( $_GET ['mode'], $modes )) {
 				$mode = $_GET ['mode'];
@@ -61,10 +66,10 @@ function yoimg_crop_load_styles_and_scripts($hook) {
 		wp_enqueue_style ( 'yoimg-cropper-css', YOIMG_CROP_URL . '/js/cropper/cropper.min.css' );
 		wp_enqueue_script( 'wp-pointer' );
 		wp_enqueue_script ( 'yoimg-cropper-js', YOIMG_CROP_URL . '/js/cropper/cropper.min.js', array (
-				'jquery' 
+				'jquery'
 		), false, true );
 		wp_enqueue_script ( 'yoimg-cropping-js', YOIMG_CROP_URL . '/js/yoimg-cropping.js', array (
-				'yoimg-cropper-js' 
+				'yoimg-cropper-js'
 		), false, true );
 	}
 }

--- a/inc/init.php
+++ b/inc/init.php
@@ -14,16 +14,15 @@ if (is_admin () || php_sapi_name () == 'cli') {
 			60
 	) ) );
 	$yoimg_crop_settings = get_option ( 'yoimg_crop_settings' );
-  // var_dump($yoimg_crop_settings);
-  // die();
+
 	define ( 'YOIMG_CROP_ENABLED', $yoimg_crop_settings && isset ( $yoimg_crop_settings ['cropping_is_active'] ) ? $yoimg_crop_settings ['cropping_is_active'] : YOIMG_DEFAULT_CROP_ENABLED );
 	define ( 'YOIMG_EDIT_IMAGE_ACTION', 'yoimg-edit-thumbnails' );
   define ( 'YOIMG_DEFAULT_CROP_RETINA_ENABLED', FALSE );
 	define ( 'YOIMG_DEFAULT_CACHEBUSTER_ENABLED', FALSE );
   define ( 'YOIMG_CROP_RETINA_ENABLED', $yoimg_crop_settings && isset ( $yoimg_crop_settings ['retina_cropping_is_active'] ) ? $yoimg_crop_settings ['retina_cropping_is_active'] : YOIMG_DEFAULT_CROP_RETINA_ENABLED );
 	define ( 'YOIMG_CACHEBUSTER_ENABLED', $yoimg_crop_settings && isset ( $yoimg_crop_settings ['cachebuster_is_active'] ) ? $yoimg_crop_settings ['cachebuster_is_active'] : YOIMG_DEFAULT_CACHEBUSTER_ENABLED );
-  // define ( 'YOIMG_CROP_URL', plugins_url ( plugin_basename ( YOIMG_CROP_PATH ) ) );
-	define ( 'YOIMG_CROP_URL', '/../app/plugins/yoimages/vendor/sirulli/yoimages-crop/inc' ); // TODO: work out why the base url is sometimes wrong...
+  define ( 'YOIMG_CROP_URL', plugins_url ( plugin_basename ( YOIMG_CROP_PATH ) ) );
+
 	require_once (YOIMG_CROP_PATH . '/utils.php');
 	if (YOIMG_CROP_ENABLED) {
 		require_once (YOIMG_CROP_PATH . '/image-editor.php');

--- a/inc/js/yoimg-cropping.js
+++ b/inc/js/yoimg-cropping.js
@@ -153,7 +153,7 @@ function yoimgInitCropImage(doImmediateCrop) {
 			var currIndex = 0;
 			var activeIndex = 0;
 			var scrollLeft = 0;
-			var mediaRouterAnchors = mediaRouter.find('a'); 
+			var mediaRouterAnchors = mediaRouter.find('a');
 			mediaRouterAnchors.each(function(index) {
 				var currEl = jQuery(this);
 				mediaRouterWidth += parseInt(currEl.outerWidth(true), 10);
@@ -167,7 +167,7 @@ function yoimgInitCropImage(doImmediateCrop) {
 				function _mediaFrameVisible(index) {
 					var minScrollLeft = arrowWidth + mediaFrameRouterWidth;
 					for (var i = 0; i <= index; i++) {
-						minScrollLeft -= parseInt(jQuery(mediaRouterAnchors[i]).outerWidth(true), 10); 
+						minScrollLeft -= parseInt(jQuery(mediaRouterAnchors[i]).outerWidth(true), 10);
 					}
 					return scrollLeft < minScrollLeft;
 				}
@@ -175,7 +175,7 @@ function yoimgInitCropImage(doImmediateCrop) {
 					if ((index != currIndex || forced === true) && index > -1 && index < mediaRouterAnchors.length) {
 						scrollLeft = arrowWidth;
 						for (var i = 0; i < index; i++) {
-							scrollLeft -= parseInt(jQuery(mediaRouterAnchors[i]).outerWidth(true), 10); 
+							scrollLeft -= parseInt(jQuery(mediaRouterAnchors[i]).outerWidth(true), 10);
 						}
 						var doScroll = (scrollLeft * -1) - parseInt(jQuery(mediaRouterAnchors[index]).outerWidth(true), 10) - arrowWidth < hiddenWidth;
 						if (doScroll) {
@@ -184,7 +184,7 @@ function yoimgInitCropImage(doImmediateCrop) {
 							} else {
 								mediaRouter.animate({
 									left : scrollLeft + 'px'
-								}, 300);	
+								}, 300);
 							}
 							currIndex = index;
 						}
@@ -228,7 +228,6 @@ function yoimgInitCropImage(doImmediateCrop) {
 function yoimgCancelCropImage() {
 	jQuery('#yoimg-cropper-wrapper').remove();
 }
-
 function yoimgCropImage() {
 	jQuery('#yoimg-cropper-wrapper .spinner').addClass('is-active');
 	var data = jQuery('#yoimg-cropper').cropper('getData');
@@ -240,7 +239,10 @@ function yoimgCropImage() {
 		jQuery('img[src*=\'' + response.filename + '\']').each(function() {
 			var img = jQuery(this);
 			var imgSrc = img.attr('src');
-			imgSrc = imgSrc + (imgSrc.indexOf('?') > -1 ? '&' : '?') + '_r=' + Math.floor((Math.random() * 100) + 1);
+      console.log('img');
+      console.log(img);
+      console.log(imgSrc);
+			imgSrc = imgSrc + (imgSrc.indexOf('?') > -1 ? '&' : '?') + '_r=' + Math.floor((Math.random() * 100) + 1); // Revision (_r) here clears the cache locally
 			img.attr('src', imgSrc);
 			if (img.parents('.yoimg-not-existing-crop').length) {
 				img.parents('.yoimg-not-existing-crop').removeClass('yoimg-not-existing-crop').find('.message.error').hide();

--- a/inc/js/yoimg-cropping.js
+++ b/inc/js/yoimg-cropping.js
@@ -236,13 +236,21 @@ function yoimgCropImage() {
 	data['size'] = yoimg_image_size;
 	data['quality'] = jQuery('#yoimg-cropper-quality').val();
 	jQuery.post(ajaxurl, data, function(response) {
-		jQuery('img[src*=\'' + response.filename + '\']').each(function() {
-			var img = jQuery(this);
-			var imgSrc = img.attr('src');
-      console.log('img');
-      console.log(img);
-      console.log(imgSrc);
-			imgSrc = imgSrc + (imgSrc.indexOf('?') > -1 ? '&' : '?') + '_r=' + Math.floor((Math.random() * 100) + 1); // Revision (_r) here clears the cache locally
+    // Use the existing filename and replace with the new filename
+		jQuery('img[src*=\'' + response.previous_filename + '\']').each(function() {
+      // Define the image object and current file name and path
+      var img = jQuery(this);
+      var imgSrc = img.attr('src');
+      // Check if cachebusting is enabled or not.
+      if(response.previous_filename === response.filename) {
+        // If cachebusting isn't enabled then do frontend cachebust
+  			imgSrc = imgSrc + (imgSrc.indexOf('?') > -1 ? '&' : '?') + '_frontend_cachebust=' + Math.floor((Math.random() * 100) + 1);
+      } else {
+        // With cachebusting enabled we can use the new filename as the thumbnail
+        // replacing the existing filename with the new one in the file path.
+        imgSrc = imgSrc.replace(response.previous_filename, response.filename);
+      }
+      // Update the image tag src attribute to show the new image
 			img.attr('src', imgSrc);
 			if (img.parents('.yoimg-not-existing-crop').length) {
 				img.parents('.yoimg-not-existing-crop').removeClass('yoimg-not-existing-crop').find('.message.error').hide();


### PR DESCRIPTION
Hey sirulli,

How are you doing?

Over at [shorlist-digital](http://github.com/shortlist-digital) we've been using your plugin and it's great!

Recently we came into an issue where cropped images weren't refreshing because of many layers or external caching and CDNs. While in the admin section the image cropper adds the _r=2343 attribute the page wasn't refreshing for days or weeks or ever!

That's why I've build out a new option in the YoImages settings which lets you enable **cachebusting**. When cachebusting is enabled the `image-editor.php` file inserts a timestamp into the file url for that crop. At which point the new image file is loaded fresh!

I'd love your feedback and consideration to merge into the main repository.

All the best.

Ben